### PR TITLE
Loosen ActiveSupport dependency for Rails 4.2.0.alpha +

### DIFF
--- a/twitter_web_intents.gemspec
+++ b/twitter_web_intents.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.test_files     = Dir.glob('spec/**/*')
 
-  spec.add_dependency "activesupport", ['>= 3.0', '< 4.1']
+  spec.add_dependency "activesupport", ['>= 3.0']
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Using the Rails edge branch which is up to version 4.2, it is not possible to resolve the twitter_web_intents dependancies. The to_query method is unlikely to be depreciated.
